### PR TITLE
Point Publications header link to ADS search results

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -9,7 +9,7 @@
 
 main:
   - title: "Publications"
-    url: /publications/
+    url: 'https://ui.adsabs.harvard.edu/search/fq=%7B!type%3Daqp%20v%3D%24fq_database%7D&fq_database=(database%3Aastronomy%20OR%20database%3Aphysics)&q=%20author%3A%22stergioulas%2C%20n%22&sort=date%20desc%2C%20bibcode%20desc&p_=0'
 
   - title: "Talks"
     url: /talks/    


### PR DESCRIPTION
## Summary
- update the main navigation so "Publications" links directly to the external ADS search results page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2446d80dc832da71eb006b87daf88