### PR TITLE
Fix malformed social profile links in author config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -47,8 +47,8 @@ author:
   bitbucket        : # Username - Update with your username on the site
   codepen          : # Username
   dribbble         : # Username
-  github           : "https://github.com/niksterg"
-  kaggle           : "https://www.kaggle.com/nikolaosstergioulas"  
+  github           : "niksterg"
+  kaggle           : "nikolaosstergioulas"
   stackoverflow    : # User number or user number and name (i.e., use "1" or "1/jeff-atwood")    
 
   # Social media
@@ -69,12 +69,12 @@ author:
   steam            : # Username
   telegram         : # URL
   tumblr           : # Username
-  twitter          : "https://x.com/nikstergioulas" # Username for X / Twitter
+  twitter          : "nikstergioulas" # Username for X / Twitter
   vine             : # Username
   weibo            : # Username
   wikipedia        : # Username
   xing             : # Username
-  youtube          : "https://www.youtube.com/@nikolaosstergioulas3822" # Username
+  youtube          : "nikolaosstergioulas3822" # Username
   zhihu            : # Username
 
 # Publication Category - The following the list of publication categories and their headings


### PR DESCRIPTION
### Motivation
- Templates in the site expect social handles/usernames and were combining them with platform base URLs, producing malformed links like `https://x.com/https:/x.com/nikstergioulas`.
- Normalizing the author social fields to usernames prevents double-prefixing and ensures generated profile links are correct.

### Description
- Updated `_config.yml` author fields to use usernames instead of full URLs for `github`, `kaggle`, `twitter`, and `youtube` so templates build proper links.
- The only file changed is `_config.yml` where `github` is now `"niksterg"`, `kaggle` is `"nikolaosstergioulas"`, `twitter` is `"nikstergioulas"`, and `youtube` is `"nikolaosstergioulas3822"`.

### Testing
- Located and inspected occurrences with `rg -n` and confirmed the updated values appear in `_config.yml` using `sed -n '45,85p' _config.yml` which showed the usernames.
- There are no repository unit tests for this configuration change; the verification consisted of static file inspection which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d04c56a2a0832da382f2427df6b3e3)