### PR TITLE
Fix LinkedIn social profile config value

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -61,7 +61,7 @@ author:
   keybase          : # Username
   instagram        : # Username
   lastfm           : # Username
-  linkedin         : "https://www.linkedin.com/in/nikolaos-stergioulas/" # Username
+  linkedin         : "nikolaos-stergioulas" # Username
   mastodon         : # URL
   medium           : # URL
   pinterest        : # Username


### PR DESCRIPTION
### Motivation
- The theme templates construct LinkedIn profile URLs by prepending `https://www.linkedin.com/in/` to the configured username, so storing a full URL produced malformed links.

### Description
- Updated the `linkedin` entry in `_config.yml` to the profile username `nikolaos-stergioulas` instead of the full URL so it matches the template's expected format.

### Testing
- Attempted to run `bundle exec jekyll build`, but the build could not run in this environment because `jekler`/`jekyll` is not installed (`bundler: command not found: jekyll`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0514a6774832da7fd1d10b926b24f)